### PR TITLE
(#321) Output Page Metadata - DTM Analytics

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_biography/cgov_biography.info.yml
@@ -7,4 +7,6 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc
   - taxonomy

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/cgov_blog.info.yml
@@ -8,3 +8,6 @@ dependencies:
   - cgov_image
   - cgov_list
   - cgov_site_section
+  - metatag
+  - metatag_dc
+  - metatag_dc_advanced

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/config/install/metatag.metatag_defaults.node__cgov_blog_post.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: node__cgov_blog_post
-label: 'Content: Blog Post'
+label: "Content: Blog Post"
 tags:
+  dcterms_is_referenced_by: 'event1,event53'
   dcterms_type: cgvBlogPost

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_center/cgov_cancer_center.info.yml
@@ -8,4 +8,6 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc
   - taxonomy

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cancer_research/cgov_cancer_research.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_core/cgov_core.info.yml
@@ -22,6 +22,7 @@ dependencies:
   - language
   - media
   - metatag
+  - metatag_dc
   - node
   - options
   - page_manager_ui

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/cgov_cthp.info.yml
@@ -10,5 +10,7 @@ dependencies:
   - cgov_home_landing
   - cgov_list
   - cgov_video
+  - metatag
+  - metatag_dc
   - paragraphs_asymmetric_translation_widgets
   - pdq_cancer_information_summary

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_cthp/config/install/metatag.metatag_defaults.node__cgov_cthp.yml
@@ -5,3 +5,4 @@ id: node__cgov_cthp
 label: 'Content: Cancer Type Homepage'
 tags:
   dcterms_type: cgvCancerTypeHome
+  dcterms_audience: '[node:field_audience:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_event/cgov_event.info.yml
@@ -6,4 +6,6 @@ core: 8.x
 dependencies:
   - cgov_core
   - cgov_image
+  - metatag
+  - metatag_dc
   - taxonomy

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_home_landing/cgov_home_landing.info.yml
@@ -8,4 +8,6 @@ dependencies:
   - cgov_image
   - cgov_list
   - cgov_promo
+  - metatag
+  - metatag_dc
   - paragraphs_asymmetric_translation_widgets

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_infographic/cgov_infographic.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - cgov_media
   - media
   - image
+  - metatag
+  - metatag_dc

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_press_release/cgov_press_release.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - cgov_core
   - cgov_image
   - cgov_list
+  - metatag
+  - metatag_dc

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_video/cgov_video.info.yml
@@ -9,4 +9,6 @@ dependencies:
   - cgov_content_block
   - cgov_media
   - cgov_list
+  - metatag
+  - metatag_dc
 hidden: false

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/config/install/metatag.metatag_defaults.node__pdq_cancer_information_summary.yml
@@ -4,4 +4,5 @@ dependencies: {  }
 id: node__pdq_cancer_information_summary
 label: 'Content: PDQ Cancer Information Summary'
 tags:
-  dcterms_type:
+  dcterms_type: pdqCancerInfoSummary
+  dcterms_audience: '[node:field_pdq_audience:value]'

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_cancer_information_summary/pdq_cancer_information_summary.info.yml
@@ -5,5 +5,7 @@ description: 'The PDQ Cancer Information Summary content type'
 core: 8.x
 dependencies:
   - cgov_core
+  - metatag
+  - metatag_dc
   - paragraphs_asymmetric_translation_widgets
   - pdq_core

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/config/install/metatag.metatag_defaults.node__pdq_drug_information_summary.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: node__pdq_drug_information_summary
+label: 'Content: PDQ Drug Information Summary'
+tags:
+  dcterms_type: pdqDrugInfoSummary

--- a/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/pdq_drug_information_summary/pdq_drug_information_summary.info.yml
@@ -5,4 +5,6 @@ description: 'The PDQ Drug Information Summary content type'
 core: 8.x
 dependencies:
   - cgov_core
+  - metatag
+  - metatag_dc
   - pdq_core


### PR DESCRIPTION
* Added configs for global, Event content type and other content level metadata values
* Fixed configuration metatag dependencies