### PR TITLE
(#1781) Blog categories show empty URL for topic when migrated.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogCategories.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogCategories.php
@@ -73,7 +73,12 @@ class BlogCategories extends BlockBase implements ContainerFactoryPluginInterfac
     // Return blog category elements. TODO: clean up twig.
     $blog_categories = $this->drawBlogCategories();
     $build = [
-      '#blog_categories' => $blog_categories,
+      'blog_categories' => $blog_categories,
+      '#cache' => [
+        'tags' => [
+          'node_list',
+        ],
+      ],
     ];
     return $build;
   }
@@ -102,8 +107,8 @@ class BlogCategories extends BlockBase implements ContainerFactoryPluginInterfac
    */
   private function getCategoryUrl($tid) {
     $path = $this->blogManager->getSeriesPath();
-    $pretty_url = $this->blogManager->getTaxonomyStorage()->load($tid)->get('field_pretty_url')->value;
-    return $path . '?topic=' . $pretty_url;
+    $param = $this->blogManager->getTaxonomyStorage()->load($tid)->get('field_pretty_url')->value ?? $tid;
+    return $path . '?topic=' . $param;
   }
 
 }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogTopicIntro.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogTopicIntro.php
@@ -73,7 +73,7 @@ class BlogTopicIntro extends BlockBase implements ContainerFactoryPluginInterfac
     // Return collection of intros. TODO: clean up twig.
     $topic_intros = $this->getTopicIntros();
     $build = [
-      '#topic_intros' => $topic_intros,
+      'topic_intros' => $topic_intros,
     ];
     return $build;
   }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogTopicTitle.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogTopicTitle.php
@@ -69,7 +69,7 @@ class BlogTopicTitle extends BlockBase implements ContainerFactoryPluginInterfac
   public function build() {
     $topic_titles = $this->getTopicTitles();
     $build = [
-      '#topic_titles' => $topic_titles,
+      'topic_titles' => $topic_titles,
     ];
     return $build;
   }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Services/BlogManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Services/BlogManager.php
@@ -181,7 +181,7 @@ class BlogManager implements BlogManagerInterface {
       foreach ($taxonomy as $taxon) {
         $tid = $taxon->tid;
         $owner_nid = $this->getTaxonomyStorage()->load($tid)->get('field_owner_blog')->target_id;
-        if ($curr_nid === $owner_nid) {
+        if ($curr_nid == $owner_nid) {
           $categories[] = $taxon;
         }
       }
@@ -199,7 +199,7 @@ class BlogManager implements BlogManagerInterface {
     // Create an array of categories that match the owner Blog Series.
     foreach ($topics as $topic) {
       $tid = $topic->tid;
-      $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value;
+      $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value ?? $tid;
       $desc = $this->getTaxonomyStorage()->load($tid)->description->value;
       $descriptions[$url] = $desc;
     }
@@ -216,7 +216,7 @@ class BlogManager implements BlogManagerInterface {
     // Create an array of categories that match the owner Blog Series.
     foreach ($topics as $topic) {
       $tid = $topic->tid;
-      $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value;
+      $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value ?? $tid;
       $name = $this->getTaxonomyStorage()->load($tid)->getName();
       $names[$url] = $name;
     }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/200_blog-series.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/200_blog-series.content.yml
@@ -24,7 +24,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Cancer Currents Blog'
+            computed_path: '/news-events/cancer-currents-blog'
   field_banner_image:
     - '#process':
         callback: 'file'
@@ -63,7 +63,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Noticias'
+            computed_path: '/espanol/noticias/temas-y-relatos-blog'
   field_banner_image__ES:
     - '#process':
         callback: 'file'
@@ -108,7 +108,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'RAS Dialogue'
+            computed_path: '/research/key-initiatives/ras/ras-central/blog'
   field_about_blog: 'Join the discussion! Post comments, ask questions, and share information with RAS experts. Subscribe to receive notifications when a new RAS Dialogue article is posted.'
   field_banner_image:
   field_allow_comments: 1

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/201_blog-categories.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/201_blog-categories.content.yml
@@ -225,8 +225,6 @@
 - entity: "taxonomy_term"
   vid: "cgov_blog_topics"
   name: "RAS Conversations: Immuno-Oncology"
-  field_pretty_url:
-    value: "immuno-oncology"
   field_owner_blog:
     - target_type: 'node'
       '#process':
@@ -239,8 +237,6 @@
 - entity: "taxonomy_term"
   vid: "cgov_blog_topics"
   name: "RAS Conversations: Elizabeth Jaffee"
-  field_pretty_url:
-    value: "elizabeth-jaffee"
   field_owner_blog:
     - target_type: 'node'
       '#process':
@@ -253,8 +249,6 @@
 - entity: "taxonomy_term"
   vid: "cgov_blog_topics"
   name: "KRAS"
-  field_pretty_url:
-    value: "kras"
   field_owner_blog:
     - target_type: 'node'
       '#process':
@@ -267,8 +261,6 @@
 - entity: "taxonomy_term"
   vid: "cgov_blog_topics"
   name: "Cancer Susceptibilities"
-  field_pretty_url:
-    value: "cancer-susceptibilities"
   field_owner_blog:
     - target_type: 'node'
       '#process':

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/202_blog-post-cc.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/202_blog-post-cc.content.yml
@@ -251,7 +251,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Cancer Currents Blog'
+            computed_path: '/news-events/cancer-currents-blog'
   field_banner_image:
     - '#process':
         callback: 'file'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/250_events_views.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/250_events_views.content.yml
@@ -51,7 +51,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: "dceg-seminar-buman"
   title: "Additive, Joint, or Synergistic Health Impact of Sleep and Physical Activity? Using Novel Methods to Understand How Distinct Behaviors Impact Health - Dr. Matt Buman"
@@ -122,7 +122,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: "cell-fate"
   title: "Registration now open for Chromatin and Cell Fate Decisions in Development, Aging & Cancer"
@@ -186,7 +186,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: "2019-radiation-course"
   title: "Radiation Epidemiology & Dosimetry Course"
@@ -248,7 +248,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: 'krispy-kreme'
   title: 'Krispy Kreme Challenge'
@@ -314,7 +314,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: 'dceg-seminar-treon'
   title: 'Genomic-Based Treatment Advances in Waldenström’s Macroglobulinemia - Dr. Steven Treon, Dr. Zachary Hunter'
@@ -384,7 +384,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: 'schiffman-gordon-lecture'
   title: 'The Changing Epidemiology of HPV and Cervical Cancer: From Etiology, to Validation of Prevention Methods, to Dissemination'

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/251_events_landing.content.yml
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_yaml_content/content/251_events_landing.content.yml
@@ -14,7 +14,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: 'future-events'
   field_page_description:
@@ -48,7 +48,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'Events'
+            computed_path: '/news-events/events'
   field_pretty_url:
     value: 'past-events'
   field_page_description:
@@ -84,7 +84,7 @@
         args:
           - 'taxonomy_term'
           - vid: 'cgov_site_sections'
-            name: 'News & Events'
+            computed_path: '/news-events'
   field_page_description:
     value: 'events landing page'
   field_pretty_url:

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-categories.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-categories.html.twig
@@ -1,9 +1,9 @@
-{% if content['#blog_categories']|length > 0 %}
+{% if content.blog_categories|length > 0 %}
   <div class="slot-item">
     <div class="managed list without-date">
       <p id="Categories" tabindex="0" class="title">{% trans %}Categories{% endtrans %}</p>
       <ul>
-        {% for title, link in content['#blog_categories'] %}
+        {% for title, link in content.blog_categories %}
           <li class="general-list-item general list-item">
             <div class="title-and-desc title desc container">
               <a class="title" href="{{link}}">{{title}}</a>

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-intro.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-intro.html.twig
@@ -1,5 +1,5 @@
-{% if content['#topic_intros']|length > 0 %}
-  {% for title, desc in content['#topic_intros'] %}
+{% if content.topic_intros|length > 0 %}
+  {% for title, desc in content.topic_intros %}
     {% if title == label and desc|length > 0 %}
       <div class="blog-intro-text">
         {{desc|raw}}

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-title.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-topic-title.html.twig
@@ -1,5 +1,5 @@
-{% if content['#topic_titles']|length > 0 %}
-  {% for url, title in content['#topic_titles'] %}
+{% if content.topic_titles|length > 0 %}
+  {% for url, title in content.topic_titles %}
     {% if (title|length > 0) and url == label %}
       {{ title }}
     {% endif %}


### PR DESCRIPTION
* Set taxonomy/tid URLs as default before setting the pretty URL
* Template cleanup
* Cache tag for categories render
* Change site section yml name to computed path