### PR TITLE
(#1781) Blog categories show empty URL for topic when migrated.

### DIFF
--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogCategories.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Plugin/Block/BlogCategories.php
@@ -73,7 +73,12 @@ class BlogCategories extends BlockBase implements ContainerFactoryPluginInterfac
     // Return blog category elements. TODO: clean up twig.
     $blog_categories = $this->drawBlogCategories();
     $build = [
-      '#blog_categories' => $blog_categories,
+      'blog_categories' => $blog_categories,
+      '#cache' => [
+        'tags' => [
+          'node_list',
+        ],
+      ],
     ];
     return $build;
   }

--- a/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Services/BlogManager.php
+++ b/docroot/profiles/custom/cgov_site/modules/custom/cgov_blog/src/Services/BlogManager.php
@@ -181,7 +181,7 @@ class BlogManager implements BlogManagerInterface {
       foreach ($taxonomy as $taxon) {
         $tid = $taxon->tid;
         $owner_nid = $this->getTaxonomyStorage()->load($tid)->get('field_owner_blog')->target_id;
-        if ($curr_nid === $owner_nid) {
+        if ($curr_nid == $owner_nid) {
           $categories[] = $taxon;
         }
       }
@@ -199,7 +199,7 @@ class BlogManager implements BlogManagerInterface {
     // Create an array of categories that match the owner Blog Series.
     foreach ($topics as $topic) {
       $tid = $topic->tid;
-      $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value;
+      $url = $this->getTaxonomyStorage()->load($tid)->field_topic_pretty_url->value ?? $tid;
       $desc = $this->getTaxonomyStorage()->load($tid)->description->value;
       $descriptions[$url] = $desc;
     }
@@ -215,11 +215,18 @@ class BlogManager implements BlogManagerInterface {
 
     // Create an array of categories that match the owner Blog Series.
     foreach ($topics as $topic) {
+      // Build tid-based titles.
       $tid = $topic->tid;
-      $url = $this->getTaxonomyStorage()->load($tid)->field_pretty_url->value;
       $name = $this->getTaxonomyStorage()->load($tid)->getName();
-      $names[$url] = $name;
+      $names[$tid] = $name;
+
+      // Build url-based titles.
+      $url = $this->getTaxonomyStorage()->load($tid)->field_topic_pretty_url->value ?? FALSE;
+      if ($url) {
+        $names[$url] = $name;
+      }
     }
+
     return $names;
   }
 

--- a/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-categories.html.twig
+++ b/docroot/profiles/custom/cgov_site/themes/custom/cgov/cgov_common/templates/content/blog/block--cgov-blog-categories.html.twig
@@ -1,9 +1,9 @@
-{% if content['#blog_categories']|length > 0 %}
+{% if content.blog_categories|length > 0 %}
   <div class="slot-item">
     <div class="managed list without-date">
       <p id="Categories" tabindex="0" class="title">{% trans %}Categories{% endtrans %}</p>
       <ul>
-        {% for title, link in content['#blog_categories'] %}
+        {% for title, link in content.blog_categories %}
           <li class="general-list-item general list-item">
             <div class="title-and-desc title desc container">
               <a class="title" href="{{link}}">{{title}}</a>


### PR DESCRIPTION
* Set taxonomy/tid URLs as default before setting the pretty URL
* Cache tag for categories render
* Updated blog yaml content for consistency 
* Changed field_pretty_url to field_topic_pretty_url in taxonomy cgov_blog_topics
* Template & block cleanup